### PR TITLE
Sending a quick reply causes an error

### DIFF
--- a/send.go
+++ b/send.go
@@ -34,7 +34,7 @@ type Action string
 type Message struct {
 	Text       string      `json:"text,omitempty"`
 	Attachment *Attachment `json:"attachment,omitempty"`
-	QuickReply []QR        `json:"quick_reply,omitempty"`
+	QuickReply []QR        `json:"quick_replies,omitempty"`
 }
 
 func (m *Message) AddQR(q ...QR) {


### PR DESCRIPTION
The problem was simply that the incorrect key was being sent in the request.  It should be `quick_replies`