### PR TITLE
fix: entry.id is a string, not an numeric value

### DIFF
--- a/receive.go
+++ b/receive.go
@@ -10,7 +10,7 @@ type Response struct {
 
 // This defines an Entry in the payload by webhook
 type Entry struct {
-	PageID    int64      `json:"id"`
+	PageID    string     `json:"id"`
 	Time      int64      `json:"time"`
 	Messaging []Callback `json:"messaging"`
 }


### PR DESCRIPTION
Currently (24 Feb 2017) json.Unmarshal fails without this fix