### PR TITLE
add IsEcho and update IsMessage() to exclude echoes

### DIFF
--- a/receive.go
+++ b/receive.go
@@ -35,7 +35,7 @@ type Callback struct {
 }
 
 func (c Callback) IsMessage() bool {
-	return !(c.Message.Text == "" && len(c.Message.Attachments) == 0)
+	return (c.Message.Text != "" || len(c.Message.Attachments) != 0) && !c.Message.IsEcho
 }
 
 func (c Callback) IsOptin() bool {
@@ -70,6 +70,7 @@ type InputOptin struct {
 // If text message only Text field exists
 // If media message Attachments fields contains an array of attachmensts sent
 type InputMessage struct {
+	IsEcho      bool              `json:"is_echo,omitempty"`
 	MID         string            `json:"mid"`
 	Seq         int64             `json:"seq"`
 	Text        string            `json:"text"`


### PR DESCRIPTION
If you subscribe your bot to message_echoes, then you need to treat echoes differently from incoming, or you risk causing infinite loops.

I think that tweaking IsMessage() is the sensible thing to do, but you might disagree. I have only tried it out for about 5 seconds in my little test app, to verify that it solves my infinite loop. If you only want the IsEcho part of the patch then that's fine too.